### PR TITLE
Add `filterNetwork ` to replay to filter req/res. Add `fullOffline` mode for offline transport

### DIFF
--- a/packages/browser/src/transports/offline.ts
+++ b/packages/browser/src/transports/offline.ts
@@ -25,6 +25,9 @@ import { parseEnvelope, serializeEnvelope } from '@sentry/utils';
 // limitations under the License.
 
 type Store = <T>(callback: (store: IDBObjectStore) => T | PromiseLike<T>) => Promise<T>;
+type SuccessRequestCallback<T> = (data: T) => void;
+type ErrorRequestCallback = (error: DOMException) => void;
+type ItemValue = Uint8Array | string;
 
 function promisifyRequest<T = undefined>(request: IDBRequest<T> | IDBTransaction): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -33,6 +36,13 @@ function promisifyRequest<T = undefined>(request: IDBRequest<T> | IDBTransaction
     // @ts-ignore - file size hacks
     request.onabort = request.onerror = () => reject(request.error);
   });
+}
+
+function makeRequest<T = undefined>(request: IDBRequest<T>, callback: SuccessRequestCallback<T>, errorCallback?: ErrorRequestCallback) {
+  // @ts-ignore - file size hacks
+  request.oncomplete = request.onsuccess = () => callback(request.result);
+  // @ts-ignore - file size hacks
+  request.onabort = request.onerror = () => errorCallback?.(request.error);
 }
 
 /** Create or open an IndexedDb store */
@@ -48,10 +58,14 @@ function keys(store: IDBObjectStore): Promise<number[]> {
   return promisifyRequest(store.getAllKeys() as IDBRequest<number[]>);
 }
 
+function keysRequest(store: IDBObjectStore, callback: SuccessRequestCallback<number[]>) {
+  makeRequest<number[]>(store.getAllKeys() as IDBRequest<number[]>, callback);
+}
+
 /** Insert into the store */
-export function insert(store: Store, value: Uint8Array | string, maxQueueSize: number, toStart = false): Promise<void> {
+export function insert(store: Store, value: ItemValue, maxQueueSize: number, toStart = false): Promise<void> {
   return store(store => {
-    return keys(store).then(keys => {
+    keysRequest(store, (keys) => {
       if (keys.length >= maxQueueSize) {
         console.log('!!!!!!!!!!!!!!!! Queue is full') // todo: remove
         return;
@@ -60,24 +74,24 @@ export function insert(store: Store, value: Uint8Array | string, maxQueueSize: n
       // We insert with an incremented key so that the entries are popped in order
       const key = toStart ? 0 : Math.max(...keys, 0) + 1;
       store.put(value, key);
-      return promisifyRequest(store.transaction);
     });
+    return promisifyRequest(store.transaction);
   });
 }
 
 /** Pop the oldest value from the store */
-export function pop(store: Store, offset = 0): Promise<Uint8Array | string | undefined> {
+export function pop(store: Store, offset = 0): Promise<ItemValue> {
   return store(store => {
-    return keys(store).then(keys => {
-      if (keys.length === 0) {
-        return undefined;
+    let value: ItemValue;
+    keysRequest(store, (keys) => {
+      if (keys.length) {
+        makeRequest<ItemValue>(store.get(keys[offset]) as IDBRequest<ItemValue>, (res) => {
+          value = res;
+          store.delete(keys[offset]);
+        });
       }
-
-      return promisifyRequest(store.get(keys[offset])).then(value => {
-        store.delete(keys[offset]);
-        return promisifyRequest(store.transaction).then(() => value);
-      });
     });
+    return promisifyRequest(store.transaction).then(() => value);
   });
 }
 

--- a/packages/browser/src/transports/offline.ts
+++ b/packages/browser/src/transports/offline.ts
@@ -49,33 +49,52 @@ function keys(store: IDBObjectStore): Promise<number[]> {
 }
 
 /** Insert into the store */
-export function insert(store: Store, value: Uint8Array | string, maxQueueSize: number): Promise<void> {
+export function insert(store: Store, value: Uint8Array | string, maxQueueSize: number, toStart = false): Promise<void> {
   return store(store => {
     return keys(store).then(keys => {
       if (keys.length >= maxQueueSize) {
+        console.log('!!!!!!!!!!!!!!!! Queue is full') // todo: remove
         return;
       }
 
       // We insert with an incremented key so that the entries are popped in order
-      store.put(value, Math.max(...keys, 0) + 1);
+      const key = toStart ? 0 : Math.max(...keys, 0) + 1;
+      store.put(value, key);
       return promisifyRequest(store.transaction);
     });
   });
 }
 
 /** Pop the oldest value from the store */
-export function pop(store: Store): Promise<Uint8Array | string | undefined> {
+export function pop(store: Store, offset = 0): Promise<Uint8Array | string | undefined> {
   return store(store => {
     return keys(store).then(keys => {
       if (keys.length === 0) {
         return undefined;
       }
 
-      return promisifyRequest(store.get(keys[0])).then(value => {
-        store.delete(keys[0]);
+      return promisifyRequest(store.get(keys[offset])).then(value => {
+        store.delete(keys[offset]);
         return promisifyRequest(store.transaction).then(() => value);
       });
     });
+  });
+}
+
+/** Get store values size */
+export function size(store: Store): Promise<number> {
+  return store(store => {
+    return keys(store).then(keys => {
+      return keys.length;
+    });
+  });
+}
+
+/** Clear store */
+export function clear(store: Store): Promise<void> {
+  return store(store => {
+    store.clear();
+    return promisifyRequest(store.transaction);
   });
 }
 
@@ -115,26 +134,34 @@ function createIndexedDbStore(options: BrowserOfflineTransportOptions): OfflineS
   }
 
   return {
-    insert: async (env: Envelope) => {
+    size: async () => {
+      return await size(getStore());
+    },
+    clear: async () => {
+      return await clear(getStore());
+    },
+    insert: async (env: Envelope, toStart = false) => {
       try {
         const serialized = await serializeEnvelope(env, options.textEncoder);
-        await insert(getStore(), serialized, options.maxQueueSize || 30);
-      } catch (_) {
-        //
+        await insert(getStore(), serialized, options.maxQueueSize || 30, toStart);
+      } catch (e) {
+        console.log('!!!!!!!! ins', e) // todo: remove
       }
     },
-    pop: async () => {
+    pop: async (offset = 0) => {
       try {
-        const deserialized = await pop(getStore());
+        const deserialized = await pop(getStore(), offset);
+
         if (deserialized) {
-          return parseEnvelope(
+          const p = parseEnvelope(
             deserialized,
             options.textEncoder || new TextEncoder(),
             options.textDecoder || new TextDecoder(),
           );
+          return p;
         }
-      } catch (_) {
-        //
+      } catch (e) {
+        console.log('!!!!!!!!! pop', e) // todo: remove
       }
 
       return undefined;

--- a/packages/core/src/transports/offline.ts
+++ b/packages/core/src/transports/offline.ts
@@ -10,8 +10,10 @@ function log(msg: string, error?: Error): void {
 }
 
 export interface OfflineStore {
-  insert(env: Envelope): Promise<void>;
-  pop(): Promise<Envelope | undefined>;
+  insert(env: Envelope, toStart?: boolean): Promise<void>;
+  pop(offset?: number): Promise<Envelope | undefined>;
+  size(): Promise<number>;
+  clear(): Promise<void>;
 }
 
 export type CreateOfflineStore = (options: OfflineTransportOptions) => OfflineStore;
@@ -30,6 +32,13 @@ export interface OfflineTransportOptions extends InternalBaseTransportOptions {
   flushAtStartup?: boolean;
 
   /**
+   * Always insert data to offline store until `flush` is called manually to send all queue to server
+   *
+   * Defaults: false
+   */
+  fullOffline?: boolean;
+
+  /**
    * Called before an event is stored.
    *
    * Return false to drop the envelope rather than store it.
@@ -45,6 +54,7 @@ type Timer = number | { unref?: () => void };
 
 /**
  * Wraps a transport and stores and retries events when they fail to send.
+ * With `fullOffline` mode, it saves events to the store until `flush` is called
  *
  * @param createTransport The transport to wrap.
  */
@@ -55,8 +65,10 @@ export function makeOfflineTransport<TO>(
     const transport = createTransport(options);
     const store = options.createStore ? options.createStore(options) : undefined;
 
-    let retryDelay = START_DELAY;
+    let retryDelay = 0;
     let flushTimer: Timer | undefined;
+    let sizeToFlush = 0;
+    let flushedCnt = 0;
 
     function shouldQueue(env: Envelope, error: Error, retryDelay: number): boolean | Promise<boolean> {
       // We don't queue Session Replay envelopes because they are:
@@ -74,44 +86,63 @@ export function makeOfflineTransport<TO>(
       return true;
     }
 
-    function flushIn(delay: number): void {
+    function flushIn(delay: number, isFlushingHead = false): Promise<void> {
       if (!store) {
-        return;
+        return Promise.resolve();
       }
 
       if (flushTimer) {
         clearTimeout(flushTimer as ReturnType<typeof setTimeout>);
       }
 
-      flushTimer = setTimeout(async () => {
-        flushTimer = undefined;
+      return new Promise((resolve, _reject) => {
+        flushTimer = setTimeout(async () => {
+          flushTimer = undefined;
 
-        const found = await store.pop();
-        if (found) {
-          log('Attempting to send previously queued event');
-          void send(found).catch(e => {
-            log('Failed to retry sending', e);
-          });
+          const offset = isFlushingHead ? 0 : (sizeToFlush - flushedCnt);
+          const canPop = isFlushingHead ? flushedCnt < sizeToFlush : true;
+          const found = canPop && await store.pop(offset);
+          if (found) {
+            if (isFlushingHead) {
+              flushedCnt++;
+            }
+            log('Attempting to send previously queued event');
+            try {
+              await send(found, isFlushingHead);
+            } catch (e) {
+              // log('Failed to retry sending', e);
+              console.log('!!! Failed to retry sending', e); // todo: remove
+            }
+          }
+          if (isFlushingHead && flushedCnt === sizeToFlush) {
+            // flush end
+            sizeToFlush = 0;
+            flushedCnt = 0;
+          }
+          resolve();
+        }, delay) as Timer;
+
+        // We need to unref the timer in node.js, otherwise the node process never exit.
+        if (typeof flushTimer !== 'number' && flushTimer.unref) {
+          flushTimer.unref();
         }
-      }, delay) as Timer;
-
-      // We need to unref the timer in node.js, otherwise the node process never exit.
-      if (typeof flushTimer !== 'number' && flushTimer.unref) {
-        flushTimer.unref();
-      }
+      });
     }
 
-    function flushWithBackOff(): void {
+    async function flushWithBackOff(isFlushingHead = false): Promise<void> {
       if (flushTimer) {
         return;
       }
 
-      flushIn(retryDelay);
-
-      retryDelay = Math.min(retryDelay * 2, MAX_DELAY);
+      await flushIn(retryDelay, isFlushingHead);
     }
 
-    async function send(envelope: Envelope): Promise<void | TransportMakeRequestResponse> {
+    async function send(envelope: Envelope, isFlushingHead = false): Promise<void | TransportMakeRequestResponse> {
+      if (store && options.fullOffline && !isFlushingHead) {
+        await store.insert(envelope);
+        return {};
+      }
+
       try {
         const result = await transport.send(envelope);
 
@@ -127,14 +158,30 @@ export function makeOfflineTransport<TO>(
           }
         }
 
-        flushIn(delay);
-        retryDelay = START_DELAY;
+        retryDelay = 0;
+        if (isFlushingHead) {
+          // wait
+          await flushIn(delay, isFlushingHead);
+        } else {
+          // don't wait
+          flushIn(delay);
+        }
         return result;
       } catch (e) {
+        retryDelay = Math.max(Math.min(retryDelay * 2, MAX_DELAY), START_DELAY);
         if (store && (await shouldQueue(envelope, e as Error, retryDelay))) {
-          await store.insert(envelope);
-          flushWithBackOff();
-          log('Error sending. Event queued', e as Error);
+          if (isFlushingHead) {
+            // return back to the start of queue
+            await store.insert(envelope, true);
+            flushedCnt--;
+            console.log('Error sending. Trying to resend', e as Error); //todo: log()
+            await flushWithBackOff(isFlushingHead);
+          } else {
+            // push to the end of queue
+            await store.insert(envelope);
+            console.log('Error sending. Event queued', e as Error); //todo: log()
+            flushWithBackOff();
+          }
           return {};
         } else {
           throw e;
@@ -148,7 +195,28 @@ export function makeOfflineTransport<TO>(
 
     return {
       send,
-      flush: t => transport.flush(t),
+      flush: async t => {
+        if (options.fullOffline) {
+          if (t ?? 0 < 0) {
+            // clear storage
+            await store?.clear();
+            return true;
+          } else {
+            if (sizeToFlush > 0) {
+              // flushing in progress
+              return false;
+            } else {
+              sizeToFlush = await store?.size() || 0;
+              if (sizeToFlush > 0) {
+                await flushWithBackOff(true);
+              }
+              return true;
+            }
+          }
+        } else {
+          return await transport.flush(t);
+        }
+      },
     };
   };
 }

--- a/packages/replay-worker/package.json
+++ b/packages/replay-worker/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
     "@types/pako": "^2.0.0",
+    "@rollup/plugin-babel": "^5.3.0",
     "tslib": "^2.4.1 || ^1.9.3"
   },
   "dependencies": {

--- a/packages/replay-worker/rollup.worker.config.js
+++ b/packages/replay-worker/rollup.worker.config.js
@@ -4,6 +4,7 @@ import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import { defineConfig } from 'rollup';
 import { terser } from 'rollup-plugin-terser';
+import { getBabelOutputPlugin } from '@rollup/plugin-babel';
 
 const config = defineConfig([
   {
@@ -27,9 +28,16 @@ const config = defineConfig([
     output: {
       file: './build/npm/esm/worker.ts',
       format: 'esm',
+      plugins: [
+        getBabelOutputPlugin({
+          presets: [
+            '@babel/preset-env',
+          ],
+        })
+      ]
     },
     plugins: [
-      typescript({ tsconfig: './tsconfig.json', inlineSourceMap: false, sourceMap: false, inlineSources: false }),
+      typescript({ tsconfig: './tsconfig.worker.json', inlineSourceMap: false, sourceMap: false, inlineSources: false }),
       resolve(),
       terser({
         mangle: {

--- a/packages/replay-worker/tsconfig.worker.json
+++ b/packages/replay-worker/tsconfig.worker.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "lib": [
+      "webworker",
+      "scripthost"
+    ],
+    "esModuleInterop": true,
+    "target": "es3",
+    "strictPropertyInitialization": false
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/replay/src/coreHandlers/handleNetworkBreadcrumbs.ts
+++ b/packages/replay/src/coreHandlers/handleNetworkBreadcrumbs.ts
@@ -37,6 +37,7 @@ export function handleNetworkBreadcrumbs(replay: ReplayContainer): void {
       networkCaptureBodies,
       networkRequestHeaders,
       networkResponseHeaders,
+      filterNetwork,
     } = replay.getOptions();
 
     const options: ExtendedNetworkBreadcrumbsOptions = {
@@ -47,6 +48,7 @@ export function handleNetworkBreadcrumbs(replay: ReplayContainer): void {
       networkCaptureBodies,
       networkRequestHeaders,
       networkResponseHeaders,
+      filterNetwork,
     };
 
     if (client && client.on) {

--- a/packages/replay/src/coreHandlers/util/fetchUtils.ts
+++ b/packages/replay/src/coreHandlers/util/fetchUtils.ts
@@ -105,7 +105,7 @@ async function _prepareFetchData(
 }
 
 function _getRequestInfo(
-  { networkCaptureBodies, networkRequestHeaders }: ReplayNetworkOptions,
+  { networkCaptureBodies, networkRequestHeaders, filterNetwork }: ReplayNetworkOptions,
   input: FetchHint['input'],
   requestBodySize?: number,
 ): ReplayNetworkRequestOrResponse | undefined {
@@ -118,7 +118,7 @@ function _getRequestInfo(
   // We only want to transmit string or string-like bodies
   const requestBody = _getFetchRequestArgBody(input);
   const bodyStr = getBodyString(requestBody);
-  return buildNetworkRequestOrResponse(headers, requestBodySize, bodyStr);
+  return buildNetworkRequestOrResponse(headers, requestBodySize, bodyStr, filterNetwork);
 }
 
 async function _getResponseInfo(
@@ -127,6 +127,7 @@ async function _getResponseInfo(
     networkCaptureBodies,
     textEncoder,
     networkResponseHeaders,
+    filterNetwork,
   }: ReplayNetworkOptions & {
     textEncoder: TextEncoderInternal;
   },
@@ -159,7 +160,7 @@ async function _getResponseInfo(
     }
 
     if (networkCaptureBodies) {
-      return buildNetworkRequestOrResponse(headers, size, bodyText);
+      return buildNetworkRequestOrResponse(headers, size, bodyText, filterNetwork);
     }
 
     return buildNetworkRequestOrResponse(headers, size, undefined);

--- a/packages/replay/src/coreHandlers/util/networkUtils.ts
+++ b/packages/replay/src/coreHandlers/util/networkUtils.ts
@@ -3,6 +3,7 @@ import { dropUndefinedKeys, stringMatchesSomePattern } from '@sentry/utils';
 
 import { NETWORK_BODY_MAX_SIZE, WINDOW } from '../../constants';
 import type {
+  FilterNetwork,
   NetworkBody,
   NetworkMetaWarning,
   NetworkRequestData,
@@ -136,6 +137,7 @@ export function buildNetworkRequestOrResponse(
   headers: Record<string, string>,
   bodySize: number | undefined,
   body: string | undefined,
+  filterNetwork?: FilterNetwork,
 ): ReplayNetworkRequestOrResponse | undefined {
   if (!bodySize && Object.keys(headers).length === 0) {
     return undefined;
@@ -154,13 +156,16 @@ export function buildNetworkRequestOrResponse(
     };
   }
 
-  const info: ReplayNetworkRequestOrResponse = {
+  let info: ReplayNetworkRequestOrResponse = {
     headers,
     size: bodySize,
   };
 
   const { body: normalizedBody, warnings } = normalizeNetworkBody(body);
   info.body = normalizedBody;
+  if (filterNetwork) {
+    info = filterNetwork(info);
+  }
   if (warnings.length > 0) {
     info._meta = {
       warnings,

--- a/packages/replay/src/coreHandlers/util/xhrUtils.ts
+++ b/packages/replay/src/coreHandlers/util/xhrUtils.ts
@@ -102,11 +102,13 @@ function _prepareXhrData(
     networkRequestHeaders,
     requestBodySize,
     options.networkCaptureBodies ? getBodyString(input) : undefined,
+    options.filterNetwork,
   );
   const response = buildNetworkRequestOrResponse(
     networkResponseHeaders,
     responseBodySize,
     options.networkCaptureBodies ? hint.xhr.responseText : undefined,
+    options.filterNetwork,
   );
 
   return {

--- a/packages/replay/src/coreHandlers/util/xhrUtils.ts
+++ b/packages/replay/src/coreHandlers/util/xhrUtils.ts
@@ -24,13 +24,13 @@ export async function captureXhrBreadcrumbToReplay(
   options: ReplayNetworkOptions & { replay: ReplayContainer },
 ): Promise<void> {
   try {
-    const data = _prepareXhrData(breadcrumb, hint, options);
+    const data = await _prepareXhrData(breadcrumb, hint, options);
 
     // Create a replay performance entry from this breadcrumb
     const result = makeNetworkReplayBreadcrumb('resource.xhr', data);
     addNetworkBreadcrumb(options.replay, result);
   } catch (error) {
-    __DEBUG_BUILD__ && logger.error('[Replay] Failed to capture fetch breadcrumb', error);
+    console.error('[Replay] Failed to capture fetch breadcrumb', error); // todo: remove
   }
 }
 
@@ -59,11 +59,24 @@ export function enrichXhrBreadcrumb(
   }
 }
 
-function _prepareXhrData(
+function blobToText(blob: Blob): Promise<string | ArrayBuffer | null> {
+  return new Promise(function (resolve, reject) {
+    const reader = new FileReader();
+    reader.onload = function (ev) {
+      resolve(ev.target!.result);
+    };
+    reader.onerror = function () {
+      reject();
+    };
+    reader.readAsText(blob);
+  });
+}
+
+async function _prepareXhrData(
   breadcrumb: Breadcrumb & { data: XhrBreadcrumbData },
   hint: XhrHint,
   options: ReplayNetworkOptions,
-): ReplayNetworkRequestData | null {
+): Promise<ReplayNetworkRequestData | null> {
   const { startTimestamp, endTimestamp, input, xhr } = hint;
 
   const {
@@ -104,10 +117,20 @@ function _prepareXhrData(
     options.networkCaptureBodies ? getBodyString(input) : undefined,
     options.filterNetwork,
   );
+
+  let responseText;
+  if (options.networkCaptureBodies) {
+    if (hint.xhr.responseType === 'blob') {
+      responseText = await blobToText(hint.xhr.response) as string;
+    } else {
+      responseText = hint.xhr.responseText;
+    }
+  }
+
   const response = buildNetworkRequestOrResponse(
     networkResponseHeaders,
     responseBodySize,
-    options.networkCaptureBodies ? hint.xhr.responseText : undefined,
+    responseText,
     options.filterNetwork,
   );
 

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -79,6 +79,7 @@ export class Replay implements Integration {
     networkCaptureBodies = true,
     networkRequestHeaders = [],
     networkResponseHeaders = [],
+    filterNetwork = undefined,
 
     mask = [],
     unmask = [],
@@ -156,6 +157,7 @@ export class Replay implements Integration {
       networkRequestHeaders: _getMergedNetworkHeaders(networkRequestHeaders),
       networkResponseHeaders: _getMergedNetworkHeaders(networkResponseHeaders),
       beforeAddRecordingEvent,
+      filterNetwork,
 
       _experiments,
     };

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -58,6 +58,10 @@ export interface BeforeAddRecordingEvent {
   (event: ReplayFrameEvent): ReplayFrameEvent | null | undefined;
 }
 
+export interface FilterNetwork {
+  (info: ReplayNetworkRequestOrResponse): ReplayNetworkRequestOrResponse;
+}
+
 export interface ReplayNetworkOptions {
   /**
    * Capture request/response details for XHR/Fetch requests that match the given URLs.
@@ -84,6 +88,11 @@ export interface ReplayNetworkOptions {
    * Defaults to true.
    */
   networkCaptureBodies: boolean;
+
+  /**
+   * Allows to filter network request/response
+   */
+  filterNetwork?: FilterNetwork,
 
   /**
    * Capture the following request headers, in addition to the default ones.
@@ -295,9 +304,9 @@ export interface DeprecatedPrivacyOptions {
 
 export interface ReplayConfiguration
   extends ReplayIntegrationPrivacyOptions,
-    OptionalReplayPluginOptions,
-    DeprecatedPrivacyOptions,
-    Pick<RecordingOptions, 'maskAllText' | 'maskAllInputs'> {}
+  OptionalReplayPluginOptions,
+  DeprecatedPrivacyOptions,
+  Pick<RecordingOptions, 'maskAllText' | 'maskAllInputs'> { }
 
 interface CommonEventContext {
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4226,6 +4226,14 @@
   dependencies:
     web-streams-polyfill "^3.1.1"
 
+"@rollup/plugin-babel@^5.3.0":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
+  integrity sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    "@rollup/pluginutils" "^3.1.0"
+
 "@rollup/plugin-commonjs@24.0.0":
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-24.0.0.tgz#fb7cf4a6029f07ec42b25daa535c75b05a43f75c"


### PR DESCRIPTION
Changes:
- Added `filterNetwork` callback to modify request/response body captured by Session Replay
- Added `fullOffline` property to `OfflineTransportOptions`. With turned on, Session Replay events are always stored to browser store (IndexedDB) until `flush()` is manually called to send all events to backend (or clear store if `flush(-1)` is called)
- Fixed bug with XHR `responseText ` in IE11: it can throw `InvalidStateError` if `responseType` is `blob` https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseText#exceptions
- Fixed `TransactionInactiveError` when making IndexedDB requests in IE11. See [description of error](https://github.com/jakearchibald/idb-keyval/commit/1af0a00b1a70a678d2f9cf5e74c55a22e57324c5#r55989916)
- Transpile inline worker source code in `replay-worker` for IE11
 
todo: See `// todo: remove`

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
